### PR TITLE
Log the upstream used.

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.template
+++ b/rootfs/etc/nginx/conf.d/default.template
@@ -37,7 +37,8 @@ log_format json escape=json '{'
       '"vary": "$sent_http_vary"'
     '},'
     '"responseTime": "$request_time", '
-    '"upstreamTime": "$upstream_response_time"'
+    '"upstreamTime": "$upstream_response_time", '
+    '"upstreamAddr": "$upstream_addr"'
   '}'
 '}';
 


### PR DESCRIPTION
 If no upstream is used, then nginx logs an empty string.